### PR TITLE
feature: add metric name prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ _MongoDBDriverExporterOptions_.
 |---|---|---|---|
 | mongodbDriverCommandsSecondsHistogramBuckets | Buckets for the mongodb_driver_commands_seconds_bucket metric in seconds. Default buckets are [0.001, 0.005, 0.010, 0.020, 0.030, 0.040, 0.050, 0.100, 0.200, 0.500, 1.0, 2.0, 5.0, 10] | [0.001, 0.005, 0.010, 0.020, 0.030, 0.040, 0.050, 0.100, 0.200, 0.500, 1.0, 2.0, 5.0, 10]| 1.0.0|
 | defaultLabels | Default labels added to each metrics. | {'foo':'bar', 'alice': 3} | 1.1.0 |
-
+| prefix | Name prefix for all metrics. | 'service1_' | - |
 
 # Grafana Dashboard
 

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -28,6 +28,11 @@ export interface MongoDBDriverExporterOptions {
    * Default labels for all metrics, e.g. {'foo':'bar', alice: 3}
    */
   defaultLabels?: Record<string, string | number>
+
+  /**
+   * Name prefix for all metrics, e.g. 'service1_'
+   */
+  prefix?: string;
 }
 
 /**

--- a/src/mongoDBDriverExporter.ts
+++ b/src/mongoDBDriverExporter.ts
@@ -34,36 +34,38 @@ export class MongoDBDriverExporter {
     this.register = register
     this.options = { ...this.defaultOptions, ...options }
 
+    const prefix = options?.prefix ?? '';
+
     this.poolSize = new Gauge({
-      name: 'mongodb_driver_pool_size',
+      name: `${prefix}mongodb_driver_pool_size`,
       help: 'the current size of the connection pool, including idle and in-use members',
       labelNames: this.mergeLabelNamesWithStandardLabels(['server_address']),
       registers: [this.register]
     })
 
     this.minSize = new Gauge({
-      name: 'mongodb_driver_pool_min',
+      name: `${prefix}mongodb_driver_pool_min`,
       help: 'the minimum size of the connection pool',
       labelNames: this.mergeLabelNamesWithStandardLabels(['server_address']),
       registers: [this.register]
     })
 
     this.maxSize = new Gauge({
-      name: 'mongodb_driver_pool_max',
+      name: `${prefix}mongodb_driver_pool_max`,
       help: 'the maximum size of the connection pool',
       labelNames: this.mergeLabelNamesWithStandardLabels(['server_address']),
       registers: [this.register]
     })
 
     this.checkedOut = new Gauge({
-      name: 'mongodb_driver_pool_checkedout',
+      name: `${prefix}mongodb_driver_pool_checkedout`,
       help: 'the count of connections that are currently in use',
       labelNames: this.mergeLabelNamesWithStandardLabels(['server_address']),
       registers: [this.register]
     })
 
     this.waitQueueSize = new Gauge({
-      name: 'mongodb_driver_pool_waitqueuesize',
+      name: `${prefix}mongodb_driver_pool_waitqueuesize`,
       help: 'the current size of the wait queue for a connection from the pool',
       labelNames: this.mergeLabelNamesWithStandardLabels(['server_address']),
       registers: [this.register]
@@ -71,7 +73,7 @@ export class MongoDBDriverExporter {
 
     if (this.monitorCommands()) {
       this.commands = new Histogram({
-        name: 'mongodb_driver_commands_seconds',
+        name: `${prefix}mongodb_driver_commands_seconds`,
         help: 'Timer of mongodb commands',
         buckets: this.options.mongodbDriverCommandsSecondsHistogramBuckets,
         labelNames: this.mergeLabelNamesWithStandardLabels(['command', 'server_address', 'status']),

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -130,4 +130,55 @@ describe('test if all metrics are created with the correct parameters', () => {
       registers: [register]
     })
   })
+
+  test('tests if all metrics include the name prefix.', () => {
+    // eslint-disable-next-line no-new
+    new MongoDBDriverExporter(mongoClient, register, { prefix: 'test_' })
+
+    expect(Gauge).toBeCalledTimes(5)
+    expect(Histogram).toBeCalledTimes(1)
+
+    expect(Gauge).toHaveBeenCalledWith({
+      name: 'test_mongodb_driver_pool_size',
+      help: 'the current size of the connection pool, including idle and in-use members',
+      labelNames: ['server_address'],
+      registers: [register]
+    })
+
+    expect(Gauge).toHaveBeenCalledWith({
+      name: 'test_mongodb_driver_pool_min',
+      help: 'the minimum size of the connection pool',
+      labelNames: ['server_address'],
+      registers: [register]
+    })
+
+    expect(Gauge).toHaveBeenCalledWith({
+      name: 'test_mongodb_driver_pool_max',
+      help: 'the maximum size of the connection pool',
+      labelNames: ['server_address'],
+      registers: [register]
+    })
+
+    expect(Gauge).toHaveBeenCalledWith({
+      name: 'test_mongodb_driver_pool_checkedout',
+      help: 'the count of connections that are currently in use',
+      labelNames: ['server_address'],
+      registers: [register]
+    })
+
+    expect(Gauge).toHaveBeenCalledWith({
+      name: 'test_mongodb_driver_pool_waitqueuesize',
+      help: 'the current size of the wait queue for a connection from the pool',
+      labelNames: ['server_address'],
+      registers: [register]
+    })
+
+    expect(Histogram).toHaveBeenCalledWith({
+      name: 'test_mongodb_driver_commands_seconds',
+      help: 'Timer of mongodb commands',
+      buckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+      labelNames: ['command', 'server_address', 'status'],
+      registers: [register]
+    })
+  })
 })


### PR DESCRIPTION
Implemented a feature that allows setting a prefix to metric names.

For issue #56 