### PR TITLE
fix(tsc): build `src` only

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "ci": "npm i --save-dev && npm run format && npm run lint && npm run build && npm run test && npm run renovate:config",
     "clean": "npm run clean:dist && npm run clean:deps",
     "clean:dist": "rm -rf ./dist",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "dist/**/*.d.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
This fixes breaking change introduced in v2.2.1 (#132) by adding extra `tsconfig` that is used for build only.

This allows to build only content of `./src` directory, while also have Typescript validations for `./src` siblings — for example, `./test` directory.

Example of `npm run build` output:

![image](https://github.com/user-attachments/assets/65774ef0-51e6-4734-88b2-8f2fb699a36b)