### PR TITLE
feat: add `mongodb_driver_pool_waitqueue_seconds` Histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ The exporter provides the following metrics.
 |mongodb_driver_pool_max|the maximum size of the connection pool|<ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><ul> | 1.0.0 |
 |mongodb_driver_pool_checkedout|the count of connections that are currently in use|<ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><ul> | 1.0.0 |
 |mongodb_driver_pool_waitqueuesize|the current size of the wait queue for a connection from the pool|<ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><ul> | 1.0.0 |
-|mongodb_driver_commands_seconds_sum|Duration of the executed command in seconds| <ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><li> _command_: Name if the command </li><li> _status_: SUCCESS or ERROR </li><ul>| 1.0.0 |
-|mongodb_driver_commands_seconds_count|Number of executed commands|<ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><li> _command_: Name if the command </li><li> _status_: SUCCESS or ERROR</li><ul>| 1.0.0 |
+|mongodb_driver_pool_waitqueue_seconds_sum|Total duration of wait queue in seconds<br/>* Requires `mongodb` >=6.9.0| <ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><li> _status_: SUCCESS or FAILED </li><ul>| 2.3.0 |
+|mongodb_driver_pool_waitqueue_seconds_count|Total number of connections checked out from the waitqueue<br/>* Requires `mongodb` >=6.9.0|<ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><li> _status_: SUCCESS or FAILED</li><ul>| 2.3.0 |
+|mongodb_driver_commands_seconds_sum|Duration of the executed command in seconds| <ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><li> _command_: Name if the command </li><li> _status_: SUCCESS or FAILED </li><ul>| 1.0.0 |
+|mongodb_driver_commands_seconds_count|Number of executed commands|<ul><li>_server_address_: URL of the MongoDB Service instance where the driver is connected to </li><li> _command_: Name if the command </li><li> _status_: SUCCESS or FAILED</li><ul>| 1.0.0 |
 
 ## Example Output
 
@@ -65,6 +67,26 @@ mongodb_driver_pool_checkedout{server_address="127.0.0.3:27017"} 1
 mongodb_driver_pool_waitqueuesize{server_address="127.0.0.1:27017"} 0
 mongodb_driver_pool_waitqueuesize{server_address="127.0.0.2:27017"} 0
 mongodb_driver_pool_waitqueuesize{server_address="127.0.0.3:27017"} 0
+
+# HELP mongodb_driver_pool_waitqueue_seconds Duratrion of mongodb connection wait queue
+# TYPE mongodb_driver_pool_waitqueue_seconds histogram
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.001",server_address="127.0.0.3:27017",status="SUCCESS"} 141
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.005",server_address="127.0.0.3:27017",status="SUCCESS"} 141
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.01",server_address="127.0.0.3:27017",status="SUCCESS"} 145
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.02",server_address="127.0.0.3:27017",status="SUCCESS"} 148
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.03",server_address="127.0.0.3:27017",status="SUCCESS"} 151
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.04",server_address="127.0.0.3:27017",status="SUCCESS"} 152
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.05",server_address="127.0.0.3:27017",status="SUCCESS"} 155
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.1",server_address="127.0.0.3:27017",status="SUCCESS"} 214
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.2",server_address="127.0.0.3:27017",status="SUCCESS"} 223
+mongodb_driver_pool_waitqueue_seconds_bucket{le="0.5",server_address="127.0.0.3:27017",status="SUCCESS"} 223
+mongodb_driver_pool_waitqueue_seconds_bucket{le="1",server_address="127.0.0.3:27017",status="SUCCESS"} 223
+mongodb_driver_pool_waitqueue_seconds_bucket{le="2",server_address="127.0.0.3:27017",status="SUCCESS"} 223
+mongodb_driver_pool_waitqueue_seconds_bucket{le="5",server_address="127.0.0.3:27017",status="SUCCESS"} 223
+mongodb_driver_pool_waitqueue_seconds_bucket{le="10",server_address="127.0.0.3:27017",status="SUCCESS"} 223
+mongodb_driver_pool_waitqueue_seconds_bucket{le="+Inf",server_address="127.0.0.3:27017",status="SUCCESS"} 223
+mongodb_driver_pool_waitqueue_seconds_sum{server_address="127.0.0.3:27017",status="SUCCESS"} 6.4500000000000055
+mongodb_driver_pool_waitqueue_seconds_count{server_address="127.0.0.3:27017",status="SUCCESS"} 223
 
 # HELP mongodb_driver_commands_seconds Timer of mongodb commands
 # TYPE mongodb_driver_commands_seconds histogram
@@ -158,6 +180,7 @@ _MongoDBDriverExporterOptions_.
 |property|Description|Example|Since |
 |---|---|---|---|
 | mongodbDriverCommandsSecondsHistogramBuckets | Buckets for the mongodb_driver_commands_seconds_bucket metric in seconds. Default buckets are [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10] | [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10]| 1.0.0|
+| waitQueueSecondsHistogramBuckets | Buckets for the mongodb_driver_pool_waitqueue_seconds_bucket metric in seconds. Default buckets are [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10] | [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10]| 2.3.0|
 | defaultLabels | Default labels added to each metrics. | {'foo':'bar', 'alice': 3} | 1.1.0 |
 | prefix | Metric name prefix for all metrics. | 'service1_' | 2.1.0 |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@christiangalsterer/mongodb-driver-prometheus-exporter",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@christiangalsterer/mongodb-driver-prometheus-exporter",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "mongodb": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@christiangalsterer/mongodb-driver-prometheus-exporter",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "author": "Christian Galsterer",
   "license": "MIT",
   "description": "Prometheus exporter to monitor the MongoDB Node.js driver",

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -26,6 +26,11 @@ export interface MongoDBDriverExporterOptions {
   mongodbDriverCommandsSecondsHistogramBuckets?: number[]
 
   /**
+   * Buckets for the mongodb_driver_pool_waitqueue_seconds metric. Default buckets are [0.001, 0.005, 0.010, 0.020, 0.030, 0.040, 0.050, 0.100, 0.200, 0.500, 1.0, 2.0, 5.0, 10]
+   */
+  waitQueueSecondsHistogramBuckets?: number[]
+
+  /**
    * Default labels for all metrics, e.g. {'foo':'bar', alice: 3}
    */
   defaultLabels?: Record<string, string | number>

--- a/src/mongoDBDriverExporter.ts
+++ b/src/mongoDBDriverExporter.ts
@@ -27,7 +27,7 @@ export class MongoDBDriverExporter {
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     mongodbDriverCommandsSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    waitQueueSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+    waitQueueSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10]
   }
 
   // pool metrics
@@ -204,7 +204,9 @@ export class MongoDBDriverExporter {
   private onConnectionCheckedOut(event: ConnectionCheckedOutEvent): void {
     this.checkedOut.inc(mergeLabelsWithStandardLabels({ server_address: event.address }, this.options.defaultLabels))
     this.waitQueueSize.dec(mergeLabelsWithStandardLabels({ server_address: event.address }, this.options.defaultLabels))
-    if (event.durationMS !== undefined) { // conditional observation for backward compatibility with `mongodb` <6.9.0
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (event.durationMS !== undefined) {
+      // conditional observation for backward compatibility with `mongodb` <6.9.0
       this.waitQueueSeconds.observe(
         mergeLabelsWithStandardLabels({ server_address: event.address, status: 'SUCCESS' }, this.options.defaultLabels),
         event.durationMS / MILLISECONDS_IN_A_SECOND
@@ -214,7 +216,9 @@ export class MongoDBDriverExporter {
 
   private onConnectionCheckOutFailed(event: ConnectionCheckOutFailedEvent): void {
     this.waitQueueSize.dec(mergeLabelsWithStandardLabels({ server_address: event.address }, this.options.defaultLabels))
-    if (event.durationMS !== undefined) { // conditional observation for backward compatibility with `mongodb` <6.9.0
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (event.durationMS !== undefined) {
+      // conditional observation for backward compatibility with `mongodb` <6.9.0
       this.waitQueueSeconds.observe(
         mergeLabelsWithStandardLabels({ server_address: event.address, status: 'FAILED' }, this.options.defaultLabels),
         event.durationMS / MILLISECONDS_IN_A_SECOND

--- a/src/mongoDBDriverExporter.ts
+++ b/src/mongoDBDriverExporter.ts
@@ -25,7 +25,9 @@ export class MongoDBDriverExporter {
   private readonly options: MongoDBDriverExporterOptions
   private readonly defaultOptions: MongoDBDriverExporterOptions = {
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    mongodbDriverCommandsSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10]
+    mongodbDriverCommandsSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    waitQueueSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
   }
 
   // pool metrics
@@ -34,12 +36,14 @@ export class MongoDBDriverExporter {
   private readonly maxSize: Gauge
   private readonly checkedOut: Gauge
   private readonly waitQueueSize: Gauge
+  private readonly waitQueueSeconds: Histogram
 
   private readonly MONGODB_DRIVER_POOL_SIZE = 'mongodb_driver_pool_size'
   private readonly MONGODB_DRIVER_POOL_MIN = 'mongodb_driver_pool_min'
   private readonly MONGODB_DRIVER_POOL_MAX = 'mongodb_driver_pool_max'
   private readonly MONGODB_DRIVER_POOL_CHECKEDOUT = 'mongodb_driver_pool_checkedout'
   private readonly MONGODB_DRIVER_POOL_WAITQUEUESIZE = 'mongodb_driver_pool_waitqueuesize'
+  private readonly MONGODB_DRIVER_POOL_WAITQUEUE_SECONDS = 'mongodb_driver_pool_waitqueue_seconds'
 
   // command metrics
   private readonly commands: Histogram
@@ -104,6 +108,18 @@ export class MongoDBDriverExporter {
             name: `${prefix}${this.MONGODB_DRIVER_POOL_WAITQUEUESIZE}`,
             help: 'the current size of the wait queue for a connection from the pool',
             labelNames: mergeLabelNamesWithStandardLabels(['server_address'], this.options.defaultLabels),
+            registers: [this.register]
+          })
+
+    const waitQueueSecondsMetric = this.register.getSingleMetric(`${prefix}${this.MONGODB_DRIVER_POOL_WAITQUEUE_SECONDS}`)
+    this.waitQueueSeconds =
+      waitQueueSecondsMetric instanceof Histogram
+        ? waitQueueSecondsMetric
+        : new Histogram({
+            name: `${prefix}${this.MONGODB_DRIVER_POOL_WAITQUEUE_SECONDS}`,
+            help: 'Duration of waiting for a connection from the pool',
+            buckets: this.options.waitQueueSecondsHistogramBuckets,
+            labelNames: mergeLabelNamesWithStandardLabels(['server_address', 'status'], this.options.defaultLabels),
             registers: [this.register]
           })
 
@@ -188,10 +204,22 @@ export class MongoDBDriverExporter {
   private onConnectionCheckedOut(event: ConnectionCheckedOutEvent): void {
     this.checkedOut.inc(mergeLabelsWithStandardLabels({ server_address: event.address }, this.options.defaultLabels))
     this.waitQueueSize.dec(mergeLabelsWithStandardLabels({ server_address: event.address }, this.options.defaultLabels))
+    if (event.durationMS !== undefined) { // conditional observation for backward compatibility with `mongodb` <6.9.0
+      this.waitQueueSeconds.observe(
+        mergeLabelsWithStandardLabels({ server_address: event.address, status: 'SUCCESS' }, this.options.defaultLabels),
+        event.durationMS / MILLISECONDS_IN_A_SECOND
+      )
+    }
   }
 
   private onConnectionCheckOutFailed(event: ConnectionCheckOutFailedEvent): void {
     this.waitQueueSize.dec(mergeLabelsWithStandardLabels({ server_address: event.address }, this.options.defaultLabels))
+    if (event.durationMS !== undefined) { // conditional observation for backward compatibility with `mongodb` <6.9.0
+      this.waitQueueSeconds.observe(
+        mergeLabelsWithStandardLabels({ server_address: event.address, status: 'FAILED' }, this.options.defaultLabels),
+        event.durationMS / MILLISECONDS_IN_A_SECOND
+      )
+    }
   }
 
   private onConnectionCheckedIn(event: ConnectionCheckedInEvent): void {

--- a/test/exporter.spec.ts
+++ b/test/exporter.spec.ts
@@ -27,7 +27,7 @@ describe('tests monitorMongoDBDriver', () => {
   test('monitorMongoDBDriver calls MongoDBDriverExporter constructor with optional parameter', () => {
     const options = {
       mongodbDriverCommandsSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20],
-      waitQueueSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20],
+      waitQueueSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20]
     }
     monitorMongoDBDriver(mongoClient, register, options)
     expect(mockMongoDBDriverExporter).toHaveBeenCalledTimes(1)

--- a/test/exporter.spec.ts
+++ b/test/exporter.spec.ts
@@ -25,7 +25,10 @@ describe('tests monitorMongoDBDriver', () => {
   })
 
   test('monitorMongoDBDriver calls MongoDBDriverExporter constructor with optional parameter', () => {
-    const options = { mongodbDriverCommandsSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20] }
+    const options = {
+      mongodbDriverCommandsSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20],
+      waitQueueSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20],
+    }
     monitorMongoDBDriver(mongoClient, register, options)
     expect(mockMongoDBDriverExporter).toHaveBeenCalledTimes(1)
     expect(mockMongoDBDriverExporter).toHaveBeenCalledWith(mongoClient, register, options)

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -32,7 +32,7 @@ describe('all metrics are created with the correct parameters', () => {
     new MongoDBDriverExporter(mongoClient, register)
 
     expect(Gauge).toHaveBeenCalledTimes(5)
-    expect(Histogram).toHaveBeenCalledTimes(1)
+    expect(Histogram).toHaveBeenCalledTimes(2)
 
     expect(Gauge).toHaveBeenCalledWith({
       name: 'mongodb_driver_pool_size',
@@ -83,7 +83,7 @@ describe('all metrics are created with the correct parameters', () => {
     new MongoDBDriverExporter(mongoClient, register, options)
 
     expect(Gauge).toHaveBeenCalledTimes(5)
-    expect(Histogram).toHaveBeenCalledTimes(1)
+    expect(Histogram).toHaveBeenCalledTimes(2)
 
     expect(Gauge).toHaveBeenCalledWith({
       name: 'mongodb_driver_pool_size',
@@ -134,7 +134,7 @@ describe('all metrics are created with the correct parameters', () => {
     new MongoDBDriverExporter(mongoClient, register, { prefix: 'test_' })
 
     expect(Gauge).toHaveBeenCalledTimes(5)
-    expect(Histogram).toHaveBeenCalledTimes(1)
+    expect(Histogram).toHaveBeenCalledTimes(2)
 
     expect(Gauge).toHaveBeenCalledWith({
       name: 'test_mongodb_driver_pool_size',

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -136,7 +136,6 @@ describe('all metrics are created with the correct parameters', () => {
       registers: [register]
     })
 
-
     expect(Histogram).toHaveBeenCalledWith({
       name: 'mongodb_driver_pool_waitqueue_seconds',
       help: 'Duration of waiting for a connection from the pool',

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -76,6 +76,14 @@ describe('all metrics are created with the correct parameters', () => {
       labelNames: ['command', 'server_address', 'status'],
       registers: [register]
     })
+
+    expect(Histogram).toHaveBeenCalledWith({
+      name: 'mongodb_driver_pool_waitqueue_seconds',
+      help: 'Duration of waiting for a connection from the pool',
+      buckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+      labelNames: ['server_address', 'status'],
+      registers: [register]
+    })
   })
 
   test('all metrics are created with default labels', () => {
@@ -127,6 +135,15 @@ describe('all metrics are created with the correct parameters', () => {
       labelNames: ['command', 'server_address', 'status', 'foo', 'alice'],
       registers: [register]
     })
+
+
+    expect(Histogram).toHaveBeenCalledWith({
+      name: 'mongodb_driver_pool_waitqueue_seconds',
+      help: 'Duration of waiting for a connection from the pool',
+      buckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+      labelNames: ['server_address', 'status', 'foo', 'alice'],
+      registers: [register]
+    })
   })
 
   test('all metrics include the name prefix.', () => {
@@ -176,6 +193,14 @@ describe('all metrics are created with the correct parameters', () => {
       help: 'Timer of mongodb commands',
       buckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
       labelNames: ['command', 'server_address', 'status'],
+      registers: [register]
+    })
+
+    expect(Histogram).toHaveBeenCalledWith({
+      name: 'test_mongodb_driver_pool_waitqueue_seconds',
+      help: 'Duration of waiting for a connection from the pool',
+      buckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+      labelNames: ['server_address', 'status'],
       registers: [register]
     })
   })

--- a/test/mongoDBDriverExporter.spec.ts
+++ b/test/mongoDBDriverExporter.spec.ts
@@ -9,7 +9,8 @@ const poolMetrics: string[] = [
   'mongodb_driver_pool_min',
   'mongodb_driver_pool_max',
   'mongodb_driver_pool_checkedout',
-  'mongodb_driver_pool_waitqueuesize'
+  'mongodb_driver_pool_waitqueuesize',
+  'mongodb_driver_pool_waitqueue_seconds'
 ]
 
 const commandMetrics: string[] = ['mongodb_driver_commands_seconds']
@@ -42,7 +43,7 @@ describe('tests mongoDBDriverExporter with real mongo client', () => {
     const mongoClient = new MongoClient('mongodb://localhost:27017', { monitorCommands: true })
     // eslint-disable-next-line no-new
     new MongoDBDriverExporter(mongoClient, register)
-    expect(register.getMetricsAsArray()).toHaveLength(6)
+    expect(register.getMetricsAsArray()).toHaveLength(poolMetrics.length + commandMetrics.length)
     expect(register.getSingleMetric('mongodb_driver_pool_size')).toBeDefined()
     expect(register.getSingleMetric('mongodb_driver_pool_min')).toBeDefined()
     expect(register.getSingleMetric('mongodb_driver_pool_max')).toBeDefined()

--- a/test/mongoDBDriverExporter.spec.ts
+++ b/test/mongoDBDriverExporter.spec.ts
@@ -50,12 +50,14 @@ describe('tests mongoDBDriverExporter with real mongo client', () => {
     expect(register.getSingleMetric('mongodb_driver_pool_checkedout')).toBeDefined()
     expect(register.getSingleMetric('mongodb_driver_pool_waitqueuesize')).toBeDefined()
     expect(register.getSingleMetric('mongodb_driver_commands_seconds')).toBeDefined()
+    expect(register.getSingleMetric('mongodb_driver_pool_waitqueue_seconds')).toBeDefined()
   })
 
   test('connection and commands metrics are registered in registry with optional configurations', () => {
     const mongoClient = new MongoClient('mongodb://localhost:27017', { monitorCommands: true })
     const options = {
       mongodbDriverCommandsSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20],
+      waitQueueSecondsHistogramBuckets: [0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 20],
       defaultLabels: { foo: 'bar', alice: 2 }
     }
     // eslint-disable-next-line no-new


### PR DESCRIPTION
## Overview

This adds new Histogram metric `mongodb_driver_pool_waitqueue_seconds`.

Default labels: `server_address`, `status`

Default buckets: `[0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10]`

MongoDB driver support: 6.9.0 and above

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/ee99df22-2a97-4f90-987a-bef3fbc8df4c" />

## Rationale

Connection pool wait queue monitoring is necessary to determine if the connection pool size is a bottleneck.

While the `mongodb_driver_pool_waitqueuesize` metric can be useful for this purpose, it is not informative enough to accurately address the potential problem:

* Due to the pull-nature of Prometheus metrics and the dynamic nature of Gauge, such a metric can hide short spikes that occurred between scrapes.
* Having this metric consistently exceed `mongodb_driver_pool_max` does not necessarily indicate a problem: the wait queue could be constantly full of many requests, each spending a fraction of a second there; or it could be a single request waiting for a long time for a connection.

Starting form `mongodb@6.9.0` ([release notes](https://github.com/mongodb/node-mongodb-native/releases/tag/v6.9.0)), `ConnectionCheckedOutEvent`/`ConnectionCheckFailedEvent` now have a `durationMS` property that represents the time between checkout start and success/failure.

This makes it possible to create a Histogram that can address the scenarios described above and precisely highlight possible issues with the connection pool.

The screenshot below shows the new metric compared to `mongodb_driver_pool_waitqueuesize` on real data:
While waitqueuesize consistently shows zero, the new metric was able to catch a large number of requests that were waiting for a connection for up to 390ms:

![Screenshot 2024-12-13 at 17 23 11](https://github.com/user-attachments/assets/09b0a3f2-e553-4ebb-be16-b64d2794f22d)

